### PR TITLE
Polling the pipe to be created during VM start

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -451,7 +451,7 @@ static convey_setup_status convey_startup(int argc, char **argv)
 	do {
 		pipe = CreateFile(conf.pipe_path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
 		rc = GetLastError();
-		if (INVALID_HANDLE_VALUE == pipe || ERROR_PIPE_BUSY == rc) {
+		if (INVALID_HANDLE_VALUE == pipe || ERROR_PIPE_BUSY == rc || ERROR_FILE_NOT_FOUND == rc) {
 			if (elapsed/1000 < conf.pipe_poll) {
 				std::this_thread::sleep_for(std::chrono::milliseconds(step));
 				elapsed += step;


### PR DESCRIPTION
It would be really useful to add the ability to wait in the polling loop until the named pipe is created upon VM start.

The use case is as follows:
* Set-VMComPort -VMName <vm name> -Number 1 -Path \\.\pipe\<pipe name>
* convey.exe \\.\pipe\<pipe name> --poll 60
* Start the Hyper-V VM and retrieve the entire console output within the convey session